### PR TITLE
Improve constructable stylesheet adoption into shadow roots

### DIFF
--- a/src/AnotherComponent.jsx
+++ b/src/AnotherComponent.jsx
@@ -1,10 +1,11 @@
 import React from "react";
+import { useShadowStyles } from "./ShadowRoot";
 import * as styles from './AnotherComponent.css' assert { type: 'css' };
 
-// Adopt all sheets into the document
-document.adoptedStyleSheets = [...document.adoptedStyleSheets, styles.default];
-
 export const AnotherComponent = () => {
+
+    useShadowStyles(styles.default);
+
     return <div className={styles.another}>
         Another Component
     </div>;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,10 @@
 import React from "react";
-import root from 'react-shadow';
 
+import { ShadowRoot } from './ShadowRoot';
 import { Component } from './Component';
 import { AnotherComponent } from './AnotherComponent';
 
 export const App = () => {
-
-    const ref = React.useRef();
-
-    React.useEffect(() => {
-        console.log(ref.current.shadowRoot.adoptedStyleSheets[0]);
-    }, []);
 
     const [anotherLoaded, setAnotherLoaded] = React.useState(false);
 
@@ -18,13 +12,14 @@ export const App = () => {
         setAnotherLoaded(true);
     }
 
-    // See "propTypes": https://www.npmjs.com/package/react-shadow
-    // Adopt the document's adoptedStyleSheets into the shadow root.
-    return <root.div 
-        ref={ref}
-        styleSheets={document.adoptedStyleSheets}>
+    return <>
+        <ShadowRoot>
             <Component />
             {!anotherLoaded && <button onClick={onBtnClick}>Load Another Component</button>}
             {anotherLoaded && <AnotherComponent />}
-    </root.div>;
+        </ShadowRoot>
+        <ShadowRoot>
+            <Component />
+        </ShadowRoot>
+    </>
 };

--- a/src/Component.jsx
+++ b/src/Component.jsx
@@ -1,10 +1,11 @@
 import React from "react";
+import { useShadowStyles } from "./ShadowRoot";
 import * as styles from './Component.css' assert { type: 'css' };
 
-// Adopt all sheets into the document
-document.adoptedStyleSheets = [...document.adoptedStyleSheets, styles.default];
-
 export const Component = () => {
+    
+    useShadowStyles(styles.default);
+
     return <div className={styles.test}>
         Hello World
     </div>;

--- a/src/ShadowRoot.jsx
+++ b/src/ShadowRoot.jsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import root from "react-shadow";
+
+// A React context for adding Constructable stylesheets to appropriate shadow roots
+export const ShadowContext = React.createContext(null);
+
+export const useShadowContext = () => {
+    return React.useContext(ShadowContext);
+};
+
+// Helper hook for adding sheets to context
+export const useShadowStyles = (styles) => {
+    const context = useShadowContext();
+    React.useEffect(() => {
+        context.addSheet(styles);
+        return () => context.removeSheet(styles);
+    }, []);
+};
+
+// Component for providing and managing context
+export const ShadowRoot = (props) => {
+
+    // Use React state to force re-render when stylesheets change
+    const [ stylesheets, setStylesheets ] = React.useState([]);
+
+    const value = React.useMemo(() => {
+        // Set makes it simple to add/remove sheets
+        const sheets = new Set();
+        return {
+            addSheet(sheet) {
+                sheets.add(sheet);
+                setStylesheets([...sheets]); // Possibly not the most efficient way to do this
+            },
+            removeSheet(sheet) {
+                sheets.delete(sheet);
+                setStylesheets([...sheets]);
+            }
+        }
+    }, []);
+
+    // Provide the context and render into a shadow root
+    return (
+        <ShadowContext.Provider value={value}>
+           <root.div styleSheets={stylesheets} {...props} />
+        </ShadowContext.Provider>);
+
+};


### PR DESCRIPTION
Adds a React Context called "ShadowContext" and a provider to manage stylesheets. ShadowContext allows shadow roots to only apply stylesheets apply to the root in question.